### PR TITLE
Add support for query option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ CREATE FOREIGN TABLE foreign_es_table (
   * `index` is the value of the index parameter to use in Elasticsearch searches.
   * `doc_type` is the value of the doc_type parameter to use in Elasticsearch searches.
   <a name="column_name_translation"></a>
+  * `query` is elastic json which will be used to restrict the data returned from the elastic index/type. This should be the same json that would go inside of the `query` parameter of an elastic search request
   * `column_name_translation` specifies whether PostgreSQL column name undergo translation when mapped to Elasticsearch field names. If the value of this option is `true`, the following translations occur:
     * An underscore (`_`) is converted to a dash (`-`)
     * A double underscore (`__`) is converted to a dot (`.`) and can be used for nested Elasticsearch fields

--- a/esfdw/es_helper.py
+++ b/esfdw/es_helper.py
@@ -85,7 +85,7 @@ class MatchList(list):
             )
 
 
-def get_filtered_query(must_list=None, must_not_list=None):
+def get_filtered_query(must_list=None, must_not_list=None, base_query=None):
     """Get the correct query string for a boolean filter. Accept must and
     must_not lists. Use MatchList for generating the appropriate lists.
     """
@@ -103,4 +103,6 @@ def get_filtered_query(must_list=None, must_not_list=None):
             }
         }
     }
+    if base_query:
+        result['query']['filtered']['query'] = base_query
     return result

--- a/esfdw/esfdw.py
+++ b/esfdw/esfdw.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import logging
 import re
+import yaml
 
 from multicorn import ForeignDataWrapper, ANY, ALL
 from multicorn.utils import log_to_postgres
@@ -36,7 +37,10 @@ class ESForeignDataWrapper(ForeignDataWrapper):
         self._esclient = None
         self._options = options
         self._columns = columns
+        self._base_query = None
         self._doc_type = options['doc_type']
+        if options.get('query'):
+            self._base_query = yaml.safe_load(options['query'])
         if options.get('column_name_translation') == 'true':
             self._column_to_es_field = self.convert_column_name
         else:
@@ -220,7 +224,8 @@ class ESForeignDataWrapper(ForeignDataWrapper):
         if must_list or must_not_list:
             query = get_filtered_query(
                 must_list=must_list,
-                must_not_list=must_not_list)
+                must_not_list=must_not_list,
+                base_query=self._base_query)
         else:
             query = {}
         # It's not clear if we should be using `fields` or `_source` here.
@@ -275,7 +280,8 @@ class ESForeignDataWrapper(ForeignDataWrapper):
         if must_list or must_not_list:
             query = get_filtered_query(
                 must_list=must_list,
-                must_not_list=must_not_list)
+                must_not_list=must_not_list,
+                base_query=self._base_query)
         else:
             query = {}
         query['size'] = 0

--- a/tests/esfdw_test.py
+++ b/tests/esfdw_test.py
@@ -490,6 +490,154 @@ class TestESIntegrationPoints(unittest.TestCase):
         expected_rows = [{'_id': 'value'}]
         self.assertEqual(rows, expected_rows)
 
+@patch('esfdw.esfdw.elasticsearch.Elasticsearch')
+class TestESIntegrationPointsQueryBased(unittest.TestCase):
+
+    def setUp(self):
+        self._columns = {
+            'f__o_o': ColumnDefinition('f__o_o', type_name='text'),
+            'bar': ColumnDefinition('bar', type_name='int'),
+            'baz': ColumnDefinition('baz', type_name='text[]'),
+            'quux': ColumnDefinition('quux', type_name='int')
+        }
+        self._fdw = ESForeignDataWrapper({'doc_type': 'foo_doc',
+                                          'index': 'our_index',
+                                          'query': '{ "bool" : { "must": [ { "range": { "bar": { "lte": 30 } } }, { "term": { "f__o_o": { "value": "bar" } } } ] } }'},
+                                         self._columns)
+        self._quals = [
+            Qual('quux', '=', '100'),
+            Qual('bar', '>', 5)
+        ]
+
+    @patch('esfdw.esfdw.scan')
+    def test_execute(self, scan_mock, _elasticsearch_mock):
+        scan_mock.return_value = [
+            {'fields': {'f__o_o': ['bar'], 'bar': [6], 'baz': ['a', 'b', 'c'], 'quux': [100]}},
+            {'fields': {'f__o_o': ['bar'], 'bar': [7], 'baz': ['d', 'e', 'f'], 'quux': [100]}},
+            {'fields': {'f__o_o': ['bar'], 'bar': [8], 'baz': ['g', 'h'], 'quux': [100]}}
+        ]
+        rows = list(
+            self._fdw.execute(
+                self._quals, [
+                    'f__o_o', 'bar', 'baz', 'quux']))
+
+        expected_query = {
+            'query': {
+                'filtered': {
+                    'filter': {
+                        'bool': {
+                            'must': [
+                                {
+                                    'term': {
+                                        'quux': '100'
+                                    },
+                                },
+                                {
+                                    'range': {
+                                        'bar': {
+                                            'gt': 5
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    'query': {
+                        'bool': {
+                            'must': [
+                                {
+                                    'range': {
+                                        'bar': {
+                                            'lte': 30
+                                        }
+                                    }
+                                },
+                                {
+                                    'term': {
+                                        'f__o_o': {
+                                            'value': 'bar'
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                    }
+                }
+            },
+            'fields': ['f__o_o', 'bar', 'baz', 'quux']
+        }
+
+        scan_mock.assert_called_once_with(
+            self._fdw.esclient,
+            query=expected_query,
+            index='our_index',
+            doc_type='foo_doc',
+            size=self._fdw._SCROLL_SIZE,
+            scroll=self._fdw._SCROLL_LENGTH)
+
+        expected_rows = [
+            {'f__o_o': 'bar', 'bar': 6, 'baz': ['a', 'b', 'c'], 'quux': 100},
+            {'f__o_o': 'bar', 'bar': 7, 'baz': ['d', 'e', 'f'], 'quux': 100},
+            {'f__o_o': 'bar', 'bar': 8, 'baz': ['g', 'h'], 'quux': 100}
+        ]
+        self.assertEqual(rows, expected_rows)
+
+    def test_get_rel_size(self, _elasticsearch_mock):
+        self._fdw.esclient.search.return_value = {
+            'hits': {
+                'total': 100
+            }
+        }
+        rel_size = self._fdw.get_rel_size(self._quals, self._columns.keys())
+        expected_query = {
+            'size': 0,
+            'query': {
+                'filtered': {
+                    'filter': {
+                        'bool': {
+                            'must': [
+                                {
+                                    'term': {
+                                        'quux': '100'
+                                    },
+                                },
+                                {
+                                    'range': {
+                                        'bar': {
+                                            'gt': 5
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    'query': {
+                        'bool': {
+                            'must': [
+                                {
+                                    'range': {
+                                        'bar': {
+                                            'lte': 30
+                                        }
+                                    }
+                                },
+                                {
+                                    'term': {
+                                        'f__o_o': {
+                                            'value': 'bar'
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                    }
+                }
+            }
+        }
+        self._fdw.esclient.search.assert_called_once_with(
+            index='our_index', body=expected_query, doc_type='foo_doc')
+        self.assertEqual(rel_size, (100, 400))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This allows users to set the `query` option on an Elastic foreign table. The supplied `query` will be used to limit the data returned from the remote elastic index/type.

@sapanshah can you take a quick look?