### PR TITLE
Add the 'es_property' column option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,14 @@ CREATE FOREIGN TABLE foreign_es_table (
   * `index` is the value of the index parameter to use in Elasticsearch searches.
   * `doc_type` is the value of the doc_type parameter to use in Elasticsearch searches.
   <a name="column_name_translation"></a>
-  * `query` is elastic json which will be used to restrict the data returned from the elastic index/type. This should be the same json that would go inside of the `query` parameter of an elastic search request
+  * `query` is elastic json which will be used to restrict the data returned from the elastic index/type. This should be the same json that would go inside of the `query` parameter of an Elasticsearch `_search` request
   * `column_name_translation` specifies whether PostgreSQL column name undergo translation when mapped to Elasticsearch field names. If the value of this option is `true`, the following translations occur:
     * An underscore (`_`) is converted to a dash (`-`)
     * A double underscore (`__`) is converted to a dot (`.`) and can be used for nested Elasticsearch fields
     * `timestamp` is mapped to `@timestamp` to match the common Logstash convention
     * For example, the PostgreSQL column name `foo__bar_baz` is converted to the Elasticsearch field `foo.bar-baz`
+  * Columns support an es_property option which maps the column to an elastic property via dot notation name. This is to handle highly nested Elasticsearch documents which result in column names that are over the
+  default PostgreSQL `NAMEDATLEN` of 63.
 
 <a name="mapping_to_schema"></a>
 #### Automatic (mostly) Elasticsearch mapping conversion to foreign table schema
@@ -114,6 +116,7 @@ The script generates a foreign table per doc_type per index, with the name of th
 Column types are translated from the Elasticsearch equivalent and are always scalar. Nested objects are not represented as JSON; instead, a column definition is generated for every nested leaf field. Elasticsearch mappings do not contain an indication of whether the field is a list field, which means that the script cannot know when to make a column an array. The schema can be fixed up manually if array columns are desired.
 
 Column names match the Elasticsearch field names except that [standard esfdw name translation rules are applied](#column_name_translation).
+Column names do not need to match the Elasticsearch field names but the `es_property` option must be set on each column and correspond to the Elasticsearch dot notation for the property.
 
 ### Debugging
 

--- a/esfdw/esfdw.py
+++ b/esfdw/esfdw.py
@@ -42,9 +42,9 @@ class ESForeignDataWrapper(ForeignDataWrapper):
         if options.get('query'):
             self._base_query = json.loads(options['query'])
         if options.get('column_name_translation') == 'true':
-            self._column_to_es_field = self.convert_column_name
+            self._convert_col = self.convert_column_name
         else:
-            self._column_to_es_field = lambda column: column
+            self._convert_col = lambda column: column
 
     @property
     def esclient(self):
@@ -66,6 +66,11 @@ class ESForeignDataWrapper(ForeignDataWrapper):
         more time-based indices.
         """
         return self._options['index']
+
+    def _column_to_es_field(self, column):
+        if 'es_property' in self._columns[column].options:
+            return self._columns[column].options['es_property']
+        return self._convert_col(column)
 
     def convert_column_name(self, column):
         """Given a column name, return the corresponding Elasticsearch field name.

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     name='esfdw',
     description='PostgreSQL foreign data wrapper for Elasticsearch - forked from https://github.com/rtkwlf/esfdw',
     long_description=long_description,
-    version='0.1.2',
+    version='0.1.3',
     author='Kyle Lilly',
     author_email='kyle@immuta.com',
     license='MIT',

--- a/tests/esfdw_test.py
+++ b/tests/esfdw_test.py
@@ -11,7 +11,19 @@ from esfdw.es_helper import MatchList
 class TestQualProcessing(unittest.TestCase):
 
     def setUp(self):
-        self._fdw = ESForeignDataWrapper({'doc_type': 'foo_doc'}, [])
+        self._columns = {
+            'foo': ColumnDefinition('foo', type_name='text', options={'es_property': 'es.foo'}),
+            'bar': ColumnDefinition('bar', type_name='int', options={'es_property': 'es.bar'}),
+            'baz': ColumnDefinition('baz', type_name='text[]', options={'es_property': 'es.baz'}),
+            'num': ColumnDefinition('num', type_name='int', options={'es_property': 'es.num'}),
+            'a': ColumnDefinition('num', type_name='text'),
+            'b': ColumnDefinition('num', type_name='text'),
+            'c': ColumnDefinition('num', type_name='text', options={'es_property': 'es.c'}),
+            'd': ColumnDefinition('num', type_name='text', options={'es_property': 'es.d'}),
+            'e': ColumnDefinition('num', type_name='int', options={'es_property': 'es.e'}),
+            'quux': ColumnDefinition('quux', type_name='int')
+        }
+        self._fdw = ESForeignDataWrapper({'doc_type': 'foo_doc'}, self._columns)
 
     def test_normalize_operator(self):
         for op in ('=', '~~', '<@', '<', '>', '<=', '>='):
@@ -68,17 +80,17 @@ class TestQualProcessing(unittest.TestCase):
             {'regexp': {'b': 'f'}}
         ]
         }, ml)
-        self.assertIn({'prefix': {'d': 'g'}}, ml)
-        self.assertIn({'regexp': {'d': 'h..*'}}, ml)
-        self.assertIn({'prefix': {'d': 'i'}}, ml)
+        self.assertIn({'prefix': {'es.d': 'g'}}, ml)
+        self.assertIn({'regexp': {'es.d': 'h..*'}}, ml)
+        self.assertIn({'prefix': {'es.d': 'i'}}, ml)
         self.assertEqual(len(mnl), 3)
         self.assertIn({'and': [
-            {'regexp': {'c': 'a.*b'}},
-            {'regexp': {'c': 'c.d'}},
-            {'regexp': {'c': '.e.*f.*'}}
+            {'regexp': {'es.c': 'a.*b'}},
+            {'regexp': {'es.c': 'c.d'}},
+            {'regexp': {'es.c': '.e.*f.*'}}
         ]
         }, mnl)
-        self.assertIn({'terms': {'e': [1, 2]}}, mnl)
+        self.assertIn({'terms': {'es.e': [1, 2]}}, mnl)
 
 
 class TestAppendFilter(unittest.TestCase):
@@ -299,10 +311,10 @@ class TestESIntegrationPoints(unittest.TestCase):
 
     def setUp(self):
         self._columns = {
-            'f__o_o': ColumnDefinition('f__o_o', type_name='text'),
+            'f__o_o': ColumnDefinition('f__o_o', type_name='text', options={'es_property': 'es.foo'}),
             'bar': ColumnDefinition('bar', type_name='int'),
             'baz': ColumnDefinition('baz', type_name='text[]'),
-            'quux': ColumnDefinition('quux', type_name='int')
+            'quux': ColumnDefinition('quux', type_name='int', options={'es_property': 'qq.quux'})
         }
         self._fdw = ESForeignDataWrapper({'doc_type': 'foo_doc',
                                           'index': 'our_index'},
@@ -315,9 +327,9 @@ class TestESIntegrationPoints(unittest.TestCase):
     @patch('esfdw.esfdw.scan')
     def test_execute(self, scan_mock, _elasticsearch_mock):
         scan_mock.return_value = [
-            {'fields': {'f__o_o': ['value'], 'bar': [6], 'baz': ['a', 'b', 'c']}},
-            {'fields': {'f__o_o': ['value'], 'bar': [7], 'baz': ['d', 'e', 'f']}},
-            {'fields': {'f__o_o': ['value'], 'bar': [8], 'baz': ['g', 'h'], 'quux': ['hi']}}
+            {'fields': {'es.foo': ['value'], 'bar': [6], 'baz': ['a', 'b', 'c']}},
+            {'fields': {'es.foo': ['value'], 'bar': [7], 'baz': ['d', 'e', 'f']}},
+            {'fields': {'es.foo': ['value'], 'bar': [8], 'baz': ['g', 'h'], 'qq.quux': ['hi']}}
         ]
         rows = list(
             self._fdw.execute(
@@ -325,7 +337,7 @@ class TestESIntegrationPoints(unittest.TestCase):
                     'f__o_o', 'bar', 'baz', 'quux']))
 
         expected_query = {
-            'fields': ['f__o_o', 'bar', 'baz', 'quux'],
+            'fields': ['es.foo', 'bar', 'baz', 'qq.quux'],
             'query': {
                 'filtered': {
                     'filter': {
@@ -333,7 +345,7 @@ class TestESIntegrationPoints(unittest.TestCase):
                             'must': [
                                 {
                                     'term': {
-                                        'f__o_o': 'value'
+                                        'es.foo': 'value'
                                     },
                                 },
                                 {
@@ -380,7 +392,7 @@ class TestESIntegrationPoints(unittest.TestCase):
                             'must': [
                                 {
                                     'term': {
-                                        'f__o_o': 'value'
+                                        'es.foo': 'value'
                                     },
                                 },
                                 {
@@ -496,13 +508,13 @@ class TestESIntegrationPointsQueryBased(unittest.TestCase):
     def setUp(self):
         self._columns = {
             'f__o_o': ColumnDefinition('f__o_o', type_name='text'),
-            'bar': ColumnDefinition('bar', type_name='int'),
+            'bar': ColumnDefinition('bar', type_name='int', options={'es_property': 'es.bar'}),
             'baz': ColumnDefinition('baz', type_name='text[]'),
             'quux': ColumnDefinition('quux', type_name='int')
         }
         self._fdw = ESForeignDataWrapper({'doc_type': 'foo_doc',
                                           'index': 'our_index',
-                                          'query': '{ "bool" : { "must": [ { "range": { "bar": { "lte": 30 } } }, { "term": { "f__o_o": { "value": "bar" } } } ] } }'},
+                                          'query': '{ "bool" : { "must": [ { "range": { "es.bar": { "lte": 30 } } }, { "term": { "f__o_o": { "value": "bar" } } } ] } }'},
                                          self._columns)
         self._quals = [
             Qual('quux', '=', '100'),
@@ -512,9 +524,9 @@ class TestESIntegrationPointsQueryBased(unittest.TestCase):
     @patch('esfdw.esfdw.scan')
     def test_execute(self, scan_mock, _elasticsearch_mock):
         scan_mock.return_value = [
-            {'fields': {'f__o_o': ['bar'], 'bar': [6], 'baz': ['a', 'b', 'c'], 'quux': [100]}},
-            {'fields': {'f__o_o': ['bar'], 'bar': [7], 'baz': ['d', 'e', 'f'], 'quux': [100]}},
-            {'fields': {'f__o_o': ['bar'], 'bar': [8], 'baz': ['g', 'h'], 'quux': [100]}}
+            {'fields': {'f__o_o': ['bar'], 'es.bar': [6], 'baz': ['a', 'b', 'c'], 'quux': [100]}},
+            {'fields': {'f__o_o': ['bar'], 'es.bar': [7], 'baz': ['d', 'e', 'f'], 'quux': [100]}},
+            {'fields': {'f__o_o': ['bar'], 'es.bar': [8], 'baz': ['g', 'h'], 'quux': [100]}}
         ]
         rows = list(self._fdw.execute([], ['f__o_o', 'bar', 'baz', 'quux']))
 
@@ -524,7 +536,7 @@ class TestESIntegrationPointsQueryBased(unittest.TestCase):
                     'must': [
                         {
                             'range': {
-                                'bar': {
+                                'es.bar': {
                                     'lte': 30
                                 }
                             }
@@ -539,7 +551,7 @@ class TestESIntegrationPointsQueryBased(unittest.TestCase):
                     ]
                 }
             },
-            'fields': ['f__o_o', 'bar', 'baz', 'quux']
+            'fields': ['f__o_o', 'es.bar', 'baz', 'quux']
         }
 
         scan_mock.assert_called_once_with(
@@ -571,7 +583,7 @@ class TestESIntegrationPointsQueryBased(unittest.TestCase):
                     'must': [
                         {
                             'range': {
-                                'bar': {
+                                'es.bar': {
                                     'lte': 30
                                 }
                             }
@@ -594,9 +606,9 @@ class TestESIntegrationPointsQueryBased(unittest.TestCase):
     @patch('esfdw.esfdw.scan')
     def test_execute_quals(self, scan_mock, _elasticsearch_mock):
         scan_mock.return_value = [
-            {'fields': {'f__o_o': ['bar'], 'bar': [6], 'baz': ['a', 'b', 'c'], 'quux': [100]}},
-            {'fields': {'f__o_o': ['bar'], 'bar': [7], 'baz': ['d', 'e', 'f'], 'quux': [100]}},
-            {'fields': {'f__o_o': ['bar'], 'bar': [8], 'baz': ['g', 'h'], 'quux': [100]}}
+            {'fields': {'f__o_o': ['bar'], 'es.bar': [6], 'baz': ['a', 'b', 'c'], 'quux': [100]}},
+            {'fields': {'f__o_o': ['bar'], 'es.bar': [7], 'baz': ['d', 'e', 'f'], 'quux': [100]}},
+            {'fields': {'f__o_o': ['bar'], 'es.bar': [8], 'baz': ['g', 'h'], 'quux': [100]}}
         ]
         rows = list(
             self._fdw.execute(
@@ -616,7 +628,7 @@ class TestESIntegrationPointsQueryBased(unittest.TestCase):
                                 },
                                 {
                                     'range': {
-                                        'bar': {
+                                        'es.bar': {
                                             'gt': 5
                                         }
                                     }
@@ -629,7 +641,7 @@ class TestESIntegrationPointsQueryBased(unittest.TestCase):
                             'must': [
                                 {
                                     'range': {
-                                        'bar': {
+                                        'es.bar': {
                                             'lte': 30
                                         }
                                     }
@@ -646,7 +658,7 @@ class TestESIntegrationPointsQueryBased(unittest.TestCase):
                     }
                 }
             },
-            'fields': ['f__o_o', 'bar', 'baz', 'quux']
+            'fields': ['f__o_o', 'es.bar', 'baz', 'quux']
         }
 
         scan_mock.assert_called_once_with(
@@ -685,7 +697,7 @@ class TestESIntegrationPointsQueryBased(unittest.TestCase):
                                 },
                                 {
                                     'range': {
-                                        'bar': {
+                                        'es.bar': {
                                             'gt': 5
                                         }
                                     }
@@ -698,7 +710,7 @@ class TestESIntegrationPointsQueryBased(unittest.TestCase):
                             'must': [
                                 {
                                     'range': {
-                                        'bar': {
+                                        'es.bar': {
                                             'lte': 30
                                         }
                                     }


### PR DESCRIPTION
@immuta/developers 

This adds the `es_property` column option which can be set when creating the table
```
CREATE FOREIGN TABLE post (
    title int OPTIONS (es_property 'report.title'),
    author text OPTIONS (column_name 'report.author.last_name'),
    email text OPTIONS (column_name 'report.author.email'),
    mobile text OPTIONS (column_name 'report.author.mobile'),
) SERVER es_srv OPTIONS (
    index 'internal_board',
    doc_type 'audits'
);
```
or by altering an existing column 
```
ALTER FOREIGN TABLE example ADD COLUMN my_col OPTIONS (es_property 'another.property')
```

Support for the automatic translation of property names is still there but the `es_property` if present takes precedence.